### PR TITLE
Update FlexCell.m

### DIFF
--- a/FlexTable/FlexCell.m
+++ b/FlexTable/FlexCell.m
@@ -60,6 +60,8 @@ static FlexCell*	sizingCell	= nil;
 	CGRect	cellFrame = sizingCell.frame;
 	cellFrame.size.width	= CGRectGetWidth(tableView.bounds);
 	sizingCell.frame	= cellFrame;
+	[sizingCell setNeedsLayout];
+	[sizingCell layoutIfNeeded];
 	NSLog(@"- table bounds %@", NSStringFromCGRect(tableView.bounds));
 	NSLog(@"  sizingCell   %@", NSStringFromCGRect(sizingCell.frame));
 	


### PR DESCRIPTION
サイズ計算用のセルでは
frame設定後

```
[sizingCell setNeedsLayout];
[sizingCell layoutIfNeeded];
```

を行わないとうまくいかない場合があることがわかりました。
なのでこちらは必ず記述したほうが良いと思います。

その分、レイアウト処理が重くなるので、高さはNSCacheでキャッシュがオススメです。
